### PR TITLE
VAAPI H265 encoding

### DIFF
--- a/gstreamer-encoder.c
+++ b/gstreamer-encoder.c
@@ -36,47 +36,20 @@ typedef struct {
 	struct obs_video_info ovi;
 } data_t;
 
-const char *gstreamer_encoder_get_name(void *type_data)
+const char *gstreamer_encoder_get_name_h264(void *type_data)
 {
-	return "GStreamer Encoder";
+	return "GStreamer Encoder h264";
 }
 
-char* gstreamer_encoder_get_codec_type(char* encoder_string)
+const char *gstreamer_encoder_get_name_h265(void *type_data)
 {
-  char* codec_type;
-  char* loc_first_space = strstr(encoder_string, " ");
-  char* h264_in_string = strstr(encoder_string, "h264");
-  char* h265_in_string = strstr(encoder_string, "h265");
-  
-  if ((h264_in_string != NULL) &&
-      (h264_in_string < loc_first_space)) {
-    codec_type = "h264";
-  } else if ((h265_in_string != NULL) &&
-	     (h265_in_string < loc_first_space)) {
-    codec_type = "h265";
-  } else {
-    blog(LOG_ERROR, "cannot determine codec type: %s\n",
-	                                encoder_string);
-    codec_type = NULL;
-  }
-  return codec_type;
+	return "GStreamer Encoder h265";
 }
 
-void *gstreamer_encoder_create(obs_data_t *settings, obs_encoder_t *encoder)
+char* gstreamer_get_format(data_t* data)
 {
-	data_t *data = g_new0(data_t, 1);
-
-	const char *format = "";
-
-	data->encoder = encoder;
-	data->settings = settings;
-
-	obs_get_video_info(&data->ovi);
-
-	data->ovi.output_width = obs_encoder_get_width(encoder);
-	data->ovi.output_height = obs_encoder_get_height(encoder);
-
-	switch (data->ovi.output_format) {
+  char* format;
+  switch (data->ovi.output_format) {
 	case VIDEO_FORMAT_I420:
 		format = "I420";
 		data->buffer_size = data->ovi.output_width *
@@ -129,8 +102,26 @@ void *gstreamer_encoder_create(obs_data_t *settings, obs_encoder_t *encoder)
 	default:
 		blog(LOG_ERROR, "unhandled output format: %d\n",
 		     data->ovi.output_format);
-		return NULL;
-	}
+		format = NULL;
+  }
+
+  return format;
+  
+}
+
+void *gstreamer_encoder_create_h264(obs_data_t *settings, obs_encoder_t *encoder)
+{
+	data_t *data = g_new0(data_t, 1);
+
+	data->encoder = encoder;
+	data->settings = settings;
+
+	obs_get_video_info(&data->ovi);
+
+	data->ovi.output_width = obs_encoder_get_width(encoder);
+	data->ovi.output_height = obs_encoder_get_height(encoder);
+
+	const char *format = gstreamer_get_format(data);
 
 	const gchar *encoder_type =
 		obs_data_get_string(data->settings, "encoder_type");
@@ -163,13 +154,6 @@ void *gstreamer_encoder_create(obs_data_t *settings, obs_encoder_t *encoder)
 			is_cbr ? "cbr" : "vbr",
 			(int)obs_data_get_int(data->settings, "keyint_sec") *
 				data->ovi.fps_num / data->ovi.fps_den);
-	} else if (g_strcmp0(encoder_type, "vaapih265enc") == 0) {
-		encoder_string = g_strdup_printf(
-			"vaapih265enc bitrate=%d rate-control=%s keyframe-period=%d",
-			(int)obs_data_get_int(data->settings, "bitrate"),
-			is_cbr ? "cbr" : "vbr",
-			(int)obs_data_get_int(data->settings, "keyint_sec") *
-				data->ovi.fps_num / data->ovi.fps_den);
 	} else if (g_strcmp0(encoder_type, "omxh264enc") == 0) {
 		encoder_string = g_strdup_printf(
 			"omxh264enc target-bitrate=%d control-rate=%s periodicity-idr=%d",
@@ -194,17 +178,74 @@ void *gstreamer_encoder_create(obs_data_t *settings, obs_encoder_t *encoder)
 		blog(LOG_ERROR, "invalid encoder selected");
 		return NULL;
 	}
-
-	char* codec_type = gstreamer_encoder_get_codec_type(encoder_string);
 	  
 	gchar *pipe_string = g_strdup_printf(
-		"appsrc name=appsrc ! video/x-raw, format=%s, width=%d, height=%d, framerate=%d/%d, interlace-mode=progressive ! videoconvert ! %s name=video_encoder  %s ! %sparse ! video/x-%s, stream-format=byte-stream, alignment=au ! appsink sync=false name=appsink",
+		"appsrc name=appsrc ! video/x-raw, format=%s, width=%d, height=%d, framerate=%d/%d, interlace-mode=progressive ! videoconvert ! %s name=video_encoder  %s ! h264parse ! video/x-h264, stream-format=byte-stream, alignment=au ! appsink sync=false name=appsink",
 		format, data->ovi.output_width, data->ovi.output_height,
 		data->ovi.fps_num, data->ovi.fps_den, encoder_string,
-		obs_data_get_string(data->settings, "extra_options"),
-		codec_type, codec_type);
+		obs_data_get_string(data->settings, "extra_options"));
 
-	blog(0, pipe_string);
+	GError *err = NULL;
+
+	data->pipe = gst_parse_launch(pipe_string, &err);
+
+	g_free(encoder_string);
+	g_free(pipe_string);
+
+	if (err != NULL) {
+		blog(LOG_ERROR, "%s", err->message);
+		return NULL;
+	}
+
+	data->appsrc = gst_bin_get_by_name(GST_BIN(data->pipe), "appsrc");
+	data->appsink = gst_bin_get_by_name(GST_BIN(data->pipe), "appsink");
+
+	gst_element_set_state(data->pipe, GST_STATE_PLAYING);
+
+	return data;
+}
+
+void *gstreamer_encoder_create_h265(obs_data_t *settings, obs_encoder_t *encoder)
+{
+	data_t *data = g_new0(data_t, 1);
+
+	data->encoder = encoder;
+	data->settings = settings;
+
+	obs_get_video_info(&data->ovi);
+
+	data->ovi.output_width = obs_encoder_get_width(encoder);
+	data->ovi.output_height = obs_encoder_get_height(encoder);
+
+	const char *format = gstreamer_get_format(data);
+
+	const gchar *encoder_type =
+		obs_data_get_string(data->settings, "encoder_type");
+
+	const gboolean is_cbr =
+		g_strcmp0(obs_data_get_string(data->settings, "rate_control"),
+			  "CBR") == 0
+			? true
+			: false;
+
+	gchar *encoder_string = "";
+	if (g_strcmp0(encoder_type, "vaapih265enc") == 0) {
+		encoder_string = g_strdup_printf(
+			"vaapih265enc bitrate=%d rate-control=%s keyframe-period=%d",
+			(int)obs_data_get_int(data->settings, "bitrate"),
+			is_cbr ? "cbr" : "vbr",
+			(int)obs_data_get_int(data->settings, "keyint_sec") *
+				data->ovi.fps_num / data->ovi.fps_den);
+	} else {
+		blog(LOG_ERROR, "invalid encoder selected");
+		return NULL;
+	}
+	  
+	gchar *pipe_string = g_strdup_printf(
+		"appsrc name=appsrc ! video/x-raw, format=%s, width=%d, height=%d, framerate=%d/%d, interlace-mode=progressive ! videoconvert ! %s name=video_encoder  %s ! h265parse ! video/x-h265, stream-format=byte-stream, alignment=au ! appsink sync=false name=appsink",
+		format, data->ovi.output_width, data->ovi.output_height,
+		data->ovi.fps_num, data->ovi.fps_den, encoder_string,
+		obs_data_get_string(data->settings, "extra_options"));
 
 	GError *err = NULL;
 
@@ -340,9 +381,18 @@ bool gstreamer_encoder_encode(void *p, struct encoder_frame *frame,
 	return true;
 }
 
-void gstreamer_encoder_get_defaults(obs_data_t *settings)
+void gstreamer_encoder_get_defaults_h264(obs_data_t *settings)
 {
 	obs_data_set_default_string(settings, "encoder_type", "x264");
+	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_string(settings, "rate_control", "CBR");
+	obs_data_set_default_int(settings, "keyint_sec", 2);
+	obs_data_set_default_bool(settings, "force_copy", false);
+}
+
+void gstreamer_encoder_get_defaults_h265(obs_data_t *settings)
+{
+	obs_data_set_default_string(settings, "encoder_type", "vaapih265enc");
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_int(settings, "keyint_sec", 2);
@@ -362,7 +412,7 @@ static bool check_feature(char *name)
 	return false;
 }
 
-obs_properties_t *gstreamer_encoder_get_properties(void *data)
+obs_properties_t *gstreamer_encoder_get_properties_h264(void *data)
 {
 	obs_properties_t *props = obs_properties_create();
 
@@ -377,9 +427,7 @@ obs_properties_t *gstreamer_encoder_get_properties(void *data)
 		obs_property_list_add_string(prop, "NVIDIA (NVENC)",
 					     "nvh264enc");
 	if (check_feature("vaapih264enc"))
-		obs_property_list_add_string(prop, "VA-API H.264", "vaapih264enc");
-	if (check_feature("vaapih265enc"))
-		obs_property_list_add_string(prop, "VA-API H.265", "vaapih265enc");
+		obs_property_list_add_string(prop, "VA-API", "vaapih264enc");
 	if (check_feature("omxh264enc"))
 		obs_property_list_add_string(prop, "OpenMAX (Raspberry Pi)",
 					     "omxh264enc");
@@ -400,6 +448,51 @@ obs_properties_t *gstreamer_encoder_get_properties(void *data)
 
 	obs_property_list_add_string(prop, "Constant bitrate", "CBR");
 	obs_property_list_add_string(prop, "Variable bitrate", "VBR");
+	obs_property_list_add_string(prop, "Constant QP", "CQP");
+	obs_property_list_add_string(prop, "Constant QP - Intelligent", "ICQ");
+	obs_property_list_add_string(prop, "Variable bitrate - Quality defined", "QVBR");
+
+	prop = obs_properties_add_int(props, "keyint_sec", "Keyframe interval",
+				      0, 20, 1);
+	//	obs_property_int_set_suffix(prop, " seconds");
+
+	prop = obs_properties_add_text(props, "extra_options",
+				       "Extra encoder options",
+				       OBS_TEXT_MULTILINE);
+	obs_property_set_long_description(
+		prop,
+		"Extra encoder options. Use the form of key=value separated by spaces.");
+
+	obs_properties_add_bool(props, "force_copy", "Force memory copy");
+
+	return props;
+}
+
+obs_properties_t *gstreamer_encoder_get_properties_h265(void *data)
+{
+	obs_properties_t *props = obs_properties_create();
+
+	obs_property_t *prop = obs_properties_add_list(props, "encoder_type",
+						       "Encoder type",
+						       OBS_COMBO_TYPE_LIST,
+						       OBS_COMBO_FORMAT_STRING);
+
+	if (check_feature("vaapih265enc"))
+		obs_property_list_add_string(prop, "VA-API", "vaapih265enc");
+
+	prop = obs_properties_add_int(props, "bitrate", "Bitrate", 50, 10000000,
+				      50);
+	//	obs_property_int_set_suffix(prop, " Kbps");
+
+	prop = obs_properties_add_list(props, "rate_control", "Rate control",
+				       OBS_COMBO_TYPE_LIST,
+				       OBS_COMBO_FORMAT_STRING);
+
+	obs_property_list_add_string(prop, "Constant bitrate", "CBR");
+	obs_property_list_add_string(prop, "Variable bitrate", "VBR");
+	obs_property_list_add_string(prop, "Constant QP", "CQP");
+	obs_property_list_add_string(prop, "Constant QP - Intelligent", "ICQ");
+	obs_property_list_add_string(prop, "Variable bitrate - Quality defined", "QVBR");
 
 	prop = obs_properties_add_int(props, "keyint_sec", "Keyframe interval",
 				      0, 20, 1);

--- a/gstreamer.c
+++ b/gstreamer.c
@@ -107,7 +107,7 @@ bool obs_module_load(void)
 	struct obs_encoder_info encoder_info = {
 		.id = "gstreamer-encoder",
 		.type = OBS_ENCODER_VIDEO,
-		.codec = "h264",
+		.codec = "hevc",
 
 		.get_name = gstreamer_encoder_get_name,
 		.create = gstreamer_encoder_create,

--- a/gstreamer.c
+++ b/gstreamer.c
@@ -37,15 +37,20 @@ extern void gstreamer_source_show(void *data);
 extern void gstreamer_source_hide(void *data);
 
 // gstreamer-encoder.c
-extern const char *gstreamer_encoder_get_name(void *type_data);
-extern void *gstreamer_encoder_create(obs_data_t *settings,
-				      obs_encoder_t *encoder);
+extern const char *gstreamer_encoder_get_name_h264(void *type_data);
+extern const char *gstreamer_encoder_get_name_h265(void *type_data);
+extern void *gstreamer_encoder_create_h264(obs_data_t *settings,
+					   obs_encoder_t *encoder);
+extern void *gstreamer_encoder_create_h265(obs_data_t *settings,
+					   obs_encoder_t *encoder);
 extern void gstreamer_encoder_destroy(void *data);
 extern bool gstreamer_encoder_encode(void *data, struct encoder_frame *frame,
 				     struct encoder_packet *packet,
 				     bool *received_packet);
-extern void gstreamer_encoder_get_defaults(obs_data_t *settings);
-extern obs_properties_t *gstreamer_encoder_get_properties(void *data);
+extern void gstreamer_encoder_get_defaults_h264(obs_data_t *settings);
+extern void gstreamer_encoder_get_defaults_h265(obs_data_t *settings);
+extern obs_properties_t *gstreamer_encoder_get_properties_h264(void *data);
+extern obs_properties_t *gstreamer_encoder_get_properties_h265(void *data);
 extern bool gstreamer_encoder_get_extra_data(void *data, uint8_t **extra_data,
 					     size_t *size);
 
@@ -104,24 +109,43 @@ bool obs_module_load(void)
 
 	obs_register_source(&source_info);
 
-	struct obs_encoder_info encoder_info = {
-		.id = "gstreamer-encoder",
+	struct obs_encoder_info encoder_info_h264 = {
+		.id = "gstreamer-encoder-h264",
 		.type = OBS_ENCODER_VIDEO,
-		.codec = "hevc",
+		.codec = "h264",
 
-		.get_name = gstreamer_encoder_get_name,
-		.create = gstreamer_encoder_create,
+		.get_name = gstreamer_encoder_get_name_h264,
+		.create = gstreamer_encoder_create_h264,
 		.destroy = gstreamer_encoder_destroy,
 
 		.encode = gstreamer_encoder_encode,
 
-		.get_defaults = gstreamer_encoder_get_defaults,
-		.get_properties = gstreamer_encoder_get_properties,
+		.get_defaults = gstreamer_encoder_get_defaults_h264,
+		.get_properties = gstreamer_encoder_get_properties_h264,
 
 		.get_extra_data = gstreamer_encoder_get_extra_data,
 	};
 
-	obs_register_encoder(&encoder_info);
+	obs_register_encoder(&encoder_info_h264);
+
+	struct obs_encoder_info encoder_info_h265 = {
+		.id = "gstreamer-encoder-h265",
+		.type = OBS_ENCODER_VIDEO,
+		.codec = "hevc",
+
+		.get_name = gstreamer_encoder_get_name_h265,
+		.create = gstreamer_encoder_create_h265,
+		.destroy = gstreamer_encoder_destroy,
+
+		.encode = gstreamer_encoder_encode,
+
+		.get_defaults = gstreamer_encoder_get_defaults_h265,
+		.get_properties = gstreamer_encoder_get_properties_h265,
+
+		.get_extra_data = gstreamer_encoder_get_extra_data,
+	};
+
+	obs_register_encoder(&encoder_info_h265);
 
 	struct obs_source_info filter_info_video = {
 		.id = "gstreamer-filter-video",


### PR DESCRIPTION
Hi, I'm trying to add support for H265 encoding to work with the VAAPI backend. I have a proof-of-concept complete, but as it stands the output is bad; there is heavy artefacting [as seen here.](https://emalm.com/?v=fVcO4) I assume this is due to my settings, so I'd appreciate some input regarding what settings I can choose to fix it. I am running this on an AMD RDNA2 discrete GPU with kernel 5.18.12, VAAPI 1.15.0 and Mesa 22.1.3 on Debian sid.

Unfortunately, I do not have hardware to test out any other H265 encoder types like nvenc. But adding these should not be too difficult.

Additionally, I added support for some extra profiles for CQP for both the h264 and the new h265 encoders.