### PR TITLE
add QSV (msdk) and nvenc/h265 codecs

### DIFF
--- a/gstreamer-encoder.c
+++ b/gstreamer-encoder.c
@@ -259,7 +259,7 @@ void *gstreamer_encoder_create_h265(obs_data_t *settings,
 			is_cbr ? "cbr" : "vbr",
 			(int)obs_data_get_int(data->settings, "keyint_sec") *
 				data->ovi.fps_num / data->ovi.fps_den);
-	} else if (g_strcmp0(encoder_type, "msdkh264enc") == 0) {
+	} else if (g_strcmp0(encoder_type, "msdkh265enc") == 0) {
 	    encoder_string = g_strdup_printf(
 			"msdkh265enc bitrate=%d rate-control=%s gop-size=%d",
 			(int)obs_data_get_int(data->settings, "bitrate"),

--- a/gstreamer-encoder.c
+++ b/gstreamer-encoder.c
@@ -180,6 +180,13 @@ void *gstreamer_encoder_create_h264(obs_data_t *settings,
 			(int)obs_data_get_int(data->settings, "bitrate"),
 			(int)obs_data_get_int(data->settings, "keyint_sec") *
 				data->ovi.fps_num / data->ovi.fps_den);
+	} else if (g_strcmp0(encoder_type, "msdkh264enc") == 0) {
+	    encoder_string = g_strdup_printf(
+			"msdkh264enc bitrate=%d rate-control=%s gop-size=%d",
+			(int)obs_data_get_int(data->settings, "bitrate"),
+			is_cbr ? "cbr" : "vbr",
+			(int)obs_data_get_int(data->settings, "keyint_sec") *
+				data->ovi.fps_num / data->ovi.fps_den);
 	} else {
 		blog(LOG_ERROR, "invalid encoder selected");
 		return NULL;
@@ -241,6 +248,20 @@ void *gstreamer_encoder_create_h265(obs_data_t *settings,
 			 obs_data_get_string(data->settings, "device"), TRUE);
 		encoder_string = g_strdup_printf(
 			"vaapih265enc bitrate=%d rate-control=%s keyframe-period=%d",
+			(int)obs_data_get_int(data->settings, "bitrate"),
+			is_cbr ? "cbr" : "vbr",
+			(int)obs_data_get_int(data->settings, "keyint_sec") *
+				data->ovi.fps_num / data->ovi.fps_den);
+	} else if (g_strcmp0(encoder_type, "nvh265enc") == 0) {
+		encoder_string = g_strdup_printf(
+			"nvh265enc bitrate=%d rc-mode=%s gop-size=%d",
+			(int)obs_data_get_int(data->settings, "bitrate"),
+			is_cbr ? "cbr" : "vbr",
+			(int)obs_data_get_int(data->settings, "keyint_sec") *
+				data->ovi.fps_num / data->ovi.fps_den);
+	} else if (g_strcmp0(encoder_type, "msdkh264enc") == 0) {
+	    encoder_string = g_strdup_printf(
+			"msdkh265enc bitrate=%d rate-control=%s gop-size=%d",
 			(int)obs_data_get_int(data->settings, "bitrate"),
 			is_cbr ? "cbr" : "vbr",
 			(int)obs_data_get_int(data->settings, "keyint_sec") *
@@ -491,6 +512,9 @@ obs_properties_t *gstreamer_encoder_get_properties_h264(void *data)
 	if (check_feature("vtenc_h264"))
 		obs_property_list_add_string(prop, "Apple (VideoToolBox)",
 					     "vtenc_h264");
+	if (check_feature("msdkh264enc"))
+		obs_property_list_add_string(prop, "Intel MSDK H264 encoder",
+						 "msdkh264enc");
 
 	prop = obs_properties_add_list(props, "device", "Device",
 				       OBS_COMBO_TYPE_LIST,
@@ -544,6 +568,11 @@ obs_properties_t *gstreamer_encoder_get_properties_h265(void *data)
 
 	if (check_feature("vaapih265enc"))
 		obs_property_list_add_string(prop, "VA-API", "vaapih265enc");
+	if (check_feature("nvh265enc"))
+		obs_property_list_add_string(prop, "NVIDIA (NVENC)", "nvh265enc");
+	if (check_feature("msdkh265enc"))
+		obs_property_list_add_string(prop, "Intel MSDK H265 encoder",
+						 "msdkh265enc");
 
 	prop = obs_properties_add_list(props, "device", "Device",
 				       OBS_COMBO_TYPE_LIST,


### PR DESCRIPTION
* nvenc/h265 tested on Linux and windows
* msdk h264/5 tested (included because way better quality than VAAPI on Intel)