### PR TITLE
Add RockChip MPP encoders support

### DIFF
--- a/gstreamer-encoder.c
+++ b/gstreamer-encoder.c
@@ -187,6 +187,13 @@ void *gstreamer_encoder_create_h264(obs_data_t *settings,
 			is_cbr ? "cbr" : "vbr",
 			(int)obs_data_get_int(data->settings, "keyint_sec") *
 				data->ovi.fps_num / data->ovi.fps_den);
+    } else if (g_strcmp0(encoder_type, "mpph264enc") == 0) {
+		encoder_string = g_strdup_printf(
+			"mpph264enc bps=%d rc-mode=%s gop=%d",
+			(int)obs_data_get_int(data->settings, "bitrate") * 1000,
+			is_cbr ? "cbr" : "vbr",
+			(int)obs_data_get_int(data->settings, "keyint_sec") *
+				data->ovi.fps_num / data->ovi.fps_den);
 	} else {
 		blog(LOG_ERROR, "invalid encoder selected");
 		return NULL;
@@ -263,6 +270,13 @@ void *gstreamer_encoder_create_h265(obs_data_t *settings,
 		encoder_string = g_strdup_printf(
 			"msdkh265enc bitrate=%d rate-control=%s gop-size=%d",
 			(int)obs_data_get_int(data->settings, "bitrate"),
+			is_cbr ? "cbr" : "vbr",
+			(int)obs_data_get_int(data->settings, "keyint_sec") *
+				data->ovi.fps_num / data->ovi.fps_den);
+    } else if (g_strcmp0(encoder_type, "mpph265enc") == 0) {
+		encoder_string = g_strdup_printf(
+			"mpph265enc bps=%d rc-mode=%s gop=%d",
+			(int)obs_data_get_int(data->settings, "bitrate") * 1000,
 			is_cbr ? "cbr" : "vbr",
 			(int)obs_data_get_int(data->settings, "keyint_sec") *
 				data->ovi.fps_num / data->ovi.fps_den);
@@ -514,7 +528,10 @@ obs_properties_t *gstreamer_encoder_get_properties_h264(void *data)
 					     "vtenc_h264");
 	if (check_feature("msdkh264enc"))
 		obs_property_list_add_string(prop, "Intel MSDK H264 encoder",
-					     "msdkh264enc");
+						 "msdkh264enc");
+    if (check_feature("mpph264enc"))
+		obs_property_list_add_string(prop, "Rockchip MPP H264 encoder",
+						 "mpph264enc");
 
 	prop = obs_properties_add_list(props, "device", "Device",
 				       OBS_COMBO_TYPE_LIST,
@@ -573,8 +590,10 @@ obs_properties_t *gstreamer_encoder_get_properties_h265(void *data)
 					     "nvh265enc");
 	if (check_feature("msdkh265enc"))
 		obs_property_list_add_string(prop, "Intel MSDK H265 encoder",
-					     "msdkh265enc");
-
+						 "msdkh265enc");
+    if (check_feature("mpph265enc"))
+		obs_property_list_add_string(prop, "Rockchip MPP H265 encoder",
+						 "mpph265enc");
 	prop = obs_properties_add_list(props, "device", "Device",
 				       OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_STRING);


### PR DESCRIPTION
Add mpph264enc and mpph265enc for Rockchip devices.  
Tested on RK3588.  