### PR TITLE
source: implement OBS media status and control callbacks

### DIFF
--- a/gstreamer-source.c
+++ b/gstreamer-source.c
@@ -411,6 +411,52 @@ int64_t gstreamer_source_get_duration(void *user_data)
 	return 0;
 }
 
+static gboolean pipeline_pause(gpointer user_data)
+{
+	data_t *data = user_data;
+
+	if (data->pipe)
+	    gst_element_set_state(data->pipe, GST_STATE_PAUSED);
+
+	return G_SOURCE_REMOVE;
+}
+
+static gboolean pipeline_play(gpointer user_data)
+{
+	data_t *data = user_data;
+
+	if (data->pipe)
+	    gst_element_set_state(data->pipe, GST_STATE_PLAYING);
+
+	return G_SOURCE_REMOVE;
+}
+
+void gstreamer_source_play_pause(void *user_data, bool pause)
+{
+	data_t *data = user_data;
+
+	g_main_context_invoke(g_main_loop_get_context(data->loop),
+			      pause ? pipeline_pause : pipeline_play,
+			      data);
+}
+
+void gstreamer_source_stop(void *user_data)
+{
+	data_t *data = user_data;
+
+	g_main_context_invoke(g_main_loop_get_context(data->loop),
+			      pipeline_destroy, data);
+
+}
+
+void gstreamer_source_restart(void *user_data)
+{
+	data_t *data = user_data;
+
+	g_main_context_invoke(g_main_loop_get_context(data->loop),
+			      pipeline_restart, data);
+}
+
 static gboolean loop_startup(gpointer user_data)
 {
 	data_t *data = user_data;

--- a/gstreamer.c
+++ b/gstreamer.c
@@ -41,6 +41,7 @@ extern int64_t gstreamer_source_get_duration(void *data);
 extern void gstreamer_source_play_pause(void *data, bool pause);
 extern void gstreamer_source_stop(void *data);
 extern void gstreamer_source_restart(void *data);
+extern void gstreamer_source_set_time(void *data, int64_t ms);
 
 // gstreamer-encoder.c
 extern const char *gstreamer_encoder_get_name_h264(void *type_data);
@@ -120,6 +121,7 @@ bool obs_module_load(void)
 		.media_play_pause = gstreamer_source_play_pause,
 		.media_stop = gstreamer_source_stop,
 		.media_restart = gstreamer_source_restart,
+		.media_set_time = gstreamer_source_set_time,
 	};
 
 	obs_register_source(&source_info);

--- a/gstreamer.c
+++ b/gstreamer.c
@@ -38,6 +38,9 @@ extern void gstreamer_source_hide(void *data);
 extern enum obs_media_state gstreamer_source_get_state(void *data);
 extern int64_t gstreamer_source_get_time(void *data);
 extern int64_t gstreamer_source_get_duration(void *data);
+extern void gstreamer_source_play_pause(void *data, bool pause);
+extern void gstreamer_source_stop(void *data);
+extern void gstreamer_source_restart(void *data);
 
 // gstreamer-encoder.c
 extern const char *gstreamer_encoder_get_name_h264(void *type_data);
@@ -98,8 +101,8 @@ bool obs_module_load(void)
 		.type = OBS_SOURCE_TYPE_INPUT,
 		.icon_type = OBS_ICON_TYPE_MEDIA,
 		.output_flags = OBS_SOURCE_ASYNC_VIDEO | OBS_SOURCE_AUDIO |
-				OBS_SOURCE_DO_NOT_DUPLICATE,
-
+				OBS_SOURCE_DO_NOT_DUPLICATE |
+				OBS_SOURCE_CONTROLLABLE_MEDIA,
 		.get_name = gstreamer_source_get_name,
 		.create = gstreamer_source_create,
 		.destroy = gstreamer_source_destroy,
@@ -113,6 +116,10 @@ bool obs_module_load(void)
 		.media_get_state = gstreamer_source_get_state,
 		.media_get_time = gstreamer_source_get_time,
 		.media_get_duration = gstreamer_source_get_duration,
+
+		.media_play_pause = gstreamer_source_play_pause,
+		.media_stop = gstreamer_source_stop,
+		.media_restart = gstreamer_source_restart,
 	};
 
 	obs_register_source(&source_info);

--- a/gstreamer.c
+++ b/gstreamer.c
@@ -35,6 +35,9 @@ extern obs_properties_t *gstreamer_source_get_properties(void *data);
 extern void gstreamer_source_update(void *data, obs_data_t *settings);
 extern void gstreamer_source_show(void *data);
 extern void gstreamer_source_hide(void *data);
+extern enum obs_media_state gstreamer_source_get_state(void *data);
+extern int64_t gstreamer_source_get_time(void *data);
+extern int64_t gstreamer_source_get_duration(void *data);
 
 // gstreamer-encoder.c
 extern const char *gstreamer_encoder_get_name_h264(void *type_data);
@@ -106,6 +109,10 @@ bool obs_module_load(void)
 		.update = gstreamer_source_update,
 		.show = gstreamer_source_show,
 		.hide = gstreamer_source_hide,
+
+		.media_get_state = gstreamer_source_get_state,
+		.media_get_time = gstreamer_source_get_time,
+		.media_get_duration = gstreamer_source_get_duration,
 	};
 
 	obs_register_source(&source_info);


### PR DESCRIPTION
I needed these features for my websocket-controlled OBS application.  Looks like other folks are looking for them too!

Fixes #70

-----

Enables multiple OBS-websocket methods and OBS GUI "Source Toolbar" controls for obs-gstreamer sources.

Implements the following OBS media status callbacks:
```
    media_get_state
    media_get_time
    media_get_duration
    media_play_pause
    media_stop
    media_restart
    media_set_time (for seek-enabled pipelines)
```
