### PR TITLE
encoder: fix compiler warnings

### DIFF
--- a/gstreamer-encoder.c
+++ b/gstreamer-encoder.c
@@ -401,7 +401,9 @@ bool gstreamer_encoder_encode(void *p, struct encoder_frame *frame,
 			}
 		}
 
-		data->codec_data = g_memdup(data->info.data, size);
+		data->codec_data = g_malloc(size);
+		memcpy(data->codec_data, data->info.data, size);
+
 		data->codec_data_size = size;
 	}
 
@@ -470,7 +472,7 @@ static void populate_vaapi_devices(obs_property_t *prop)
 	int n = scandir("/dev/dri", &list, scanfilter, versionsort);
 
 	for (int i = 0; i < n; i++) {
-		char device[64] = {0};
+		char device[16 + NAME_MAX] = {0};
 		int w = snprintf(device, sizeof(device), "/dev/dri/%s",
 				 list[i]->d_name);
 		(void)w;


### PR DESCRIPTION
This PR makes my build warning-clean.

-----

Fixes:

gstreamer-encoder.c:404:17: warning: ‘g_memdup’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]

gstreamer-encoder.c:474:68: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 55 [-Wformat-truncation=]