### PR TITLE
reinstate pipeline_destroy() call

### DIFF
--- a/gstreamer-source.c
+++ b/gstreamer-source.c
@@ -689,19 +689,8 @@ static gpointer _start(gpointer user_data)
 
 	g_main_loop_run(data->loop);
 
-	if (data->pipe != NULL) {
-		gst_element_set_state(data->pipe, GST_STATE_NULL);
-
-		GstBus *bus = gst_element_get_bus(data->pipe);
-		gst_bus_remove_watch(bus);
-		gst_object_unref(bus);
-
-		gst_object_unref(data->pipe);
-		if (data->clock != NULL)
-			gst_object_unref(data->clock);
-		data->pipe = NULL;
-		data->clock = NULL;
-	}
+	if (data->pipe)
+		pipeline_destroy(data);
 
 	g_main_loop_unref(data->loop);
 	data->loop = NULL;


### PR DESCRIPTION
pipeline_destroy() was introduced here along with a call to it from _start() as a replacement for an open-coded variation:

9831483 source: split start_pipe() and defer GST_STATE_NULL to pipeline_destroy()

But that commit's change to _start() appears to have been accidentally clobbered; looks like just a merge mix-up.  Put back the call to pipeline_destroy().

Fixes: 1e0d58e "Add latency and NTP options. (by norman and lucaspontoexe)"